### PR TITLE
Calculate the light projection matrix analytically.

### DIFF
--- a/escher/renderer.cc
+++ b/escher/renderer.cc
@@ -79,7 +79,7 @@ void Renderer::Render(const Model& model) {
   glViewport(0, 0, stage_.size().width(), stage_.size().height());
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glm::mat4 matrix = stage_.viewing_volume().GetProjectionMatrix();
-  DrawModelWithShadowShader(model, matrix, light_matrix);
+  DrawModelWithShadowShader(model, matrix);
 }
 
 void Renderer::DrawModelWithDepthShader(const Model& model,
@@ -97,13 +97,10 @@ void Renderer::DrawModelWithDepthShader(const Model& model,
 }
 
 void Renderer::DrawModelWithShadowShader(const Model& model,
-                                         const glm::mat4& matrix,
-                                         const glm::mat4& light_matrix) {
+                                         const glm::mat4& matrix) {
   glUseProgram(shadow_shader_.program().id());
   glEnableVertexAttribArray(shadow_shader_.position());
   glUniformMatrix4fv(shadow_shader_.matrix(), 1, GL_FALSE, &matrix[0][0]);
-  glUniformMatrix4fv(shadow_shader_.light_matrix(), 1, GL_FALSE,
-                     &light_matrix[0][0]);
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, shadow_map_.texture().id());
   glUniform1i(shadow_shader_.shadow_map(), 0);

--- a/escher/renderer.h
+++ b/escher/renderer.h
@@ -33,8 +33,7 @@ class Renderer {
   void DrawModelWithDepthShader(const Model& model,
                                 const glm::mat4& light_matrix);
   void DrawModelWithShadowShader(const Model& model,
-                                 const glm::mat4& projection_matrix,
-                                 const glm::mat4& light_matrix);
+                                 const glm::mat4& projection_matrix);
 
   Stage stage_;
   DepthBuffer shadow_map_;

--- a/escher/shaders/shadow_shader.h
+++ b/escher/shaders/shadow_shader.h
@@ -19,7 +19,6 @@ class ShadowShader {
   const UniqueProgram& program() const { return program_; }
 
   GLint matrix() const { return matrix_; }
-  GLint light_matrix() const { return light_matrix_; }
   GLint shadow_map() const { return shadow_map_; }
   GLint color() const { return color_; }
 
@@ -29,7 +28,6 @@ class ShadowShader {
   UniqueProgram program_;
 
   GLint matrix_ = 0;
-  GLint light_matrix_ = 0;
   GLint shadow_map_ = 0;
   GLint color_ = 0;
   GLint position_ = 0;

--- a/waterfall/waterfall.cc
+++ b/waterfall/waterfall.cc
@@ -15,6 +15,7 @@ class WaterfallApplication : public SampleApplication {
     app_bar_material_.set_color(glm::vec4(0.0f, 0.0f, 1.0f, 1.0f));
     canvas_material_.set_color(glm::vec4(1.0f, 1.0f, 1.0f, 1.0f));
     fab_material_.set_color(glm::vec4(1.0f, 0.0f, 0.0f, 1.0f));
+    green_material_.set_color(glm::vec4(0.0f, 1.0f, 0.0f, 1.0f));
   }
 
   bool initialize() override { return renderer_.Init(); }
@@ -36,6 +37,16 @@ class WaterfallApplication : public SampleApplication {
         glm::vec2(0.0f, 0.0f), glm::vec2(window_size_.width(), 56.0f), 4.0f,
         &app_bar_material_));
 
+    model.AddObject(escher::Object::CreateRect(glm::vec2(100.0f, 180.0f),
+                                               glm::vec2(60.0f, 40.0f), 12.0f,
+                                               &green_material_));
+    model.AddObject(escher::Object::CreateRect(glm::vec2(200.0f, 180.0f),
+                                               glm::vec2(60.0f, 40.0f), 16.0f,
+                                               &green_material_));
+    model.AddObject(escher::Object::CreateRect(
+        glm::vec2(0.0f, 200.0f), glm::vec2(window_size_.width(), 80.0f), 2.0f,
+        &fab_material_));
+
     // canvas
     model.AddObject(escher::Object::CreateRect(
         glm::vec2(0.0f, 0.0f), window_size_.AsVec2(), 0.0f, &canvas_material_));
@@ -53,6 +64,7 @@ class WaterfallApplication : public SampleApplication {
   escher::Material app_bar_material_;
   escher::Material canvas_material_;
   escher::Material fab_material_;
+  escher::Material green_material_;
 
   escher::TimePoint frame_time_;
   escher::SizeI window_size_;


### PR DESCRIPTION
Derive the projection of the light from the orthographic projection
of the scene by applying a skew.  This makes the shadow map coincident
with the scene being rendered.

/cc @abarth
