### PR TITLE
Account for device pixel ratio more sensibly

### DIFF
--- a/escher/renderer.cc
+++ b/escher/renderer.cc
@@ -56,8 +56,8 @@ void Renderer::ResizeBuffers(const SizeI& size) {
 }
 
 void Renderer::Render(const Stage& stage, const Model& model) {
-  if (!size_.Equals(stage.size()))
-    ResizeBuffers(stage.size());
+  if (!size_.Equals(stage.physical_size()))
+    ResizeBuffers(stage.physical_size());
 
   glm::mat4 matrix = stage.viewing_volume().GetProjectionMatrix();
   glViewport(0, 0, size_.width(), size_.height());
@@ -89,9 +89,9 @@ void Renderer::ComputeIllumination(const Stage& stage) {
   glUseProgram(occlusion_detector_.program().id());
   glUniform1i(occlusion_detector_.depth_map(), 0);
   glUniform1i(occlusion_detector_.noise(), 1);
-  auto& size = stage.size();
-  glUniform3f(occlusion_detector_.viewing_volume(), size.width(), size.height(),
-              stage.viewing_volume().depth());
+  auto& viewing_volume = stage.viewing_volume();
+  glUniform3f(occlusion_detector_.viewing_volume(), viewing_volume.width(),
+              viewing_volume.height(), viewing_volume.depth());
   auto& key_light = stage.key_light();
   glUniform4f(occlusion_detector_.key_light(), key_light.direction().x,
               key_light.direction().y, key_light.dispersion(),

--- a/escher/scene/stage.cc
+++ b/escher/scene/stage.cc
@@ -12,8 +12,11 @@ Stage::Stage() {
 Stage::~Stage() {
 }
 
-void Stage::SetSize(SizeI size) {
-  viewing_volume_ = ViewingVolume(std::move(size), viewing_volume_.near(), viewing_volume_.far());
+void Stage::Resize(SizeI size, float device_pixel_ratio) {
+  physical_size_ = std::move(size);
+  viewing_volume_ = viewing_volume_.CopyWith(
+      physical_size_.width() / device_pixel_ratio,
+      physical_size_.height() / device_pixel_ratio);
 }
 
 }  // namespace escher

--- a/escher/scene/stage.h
+++ b/escher/scene/stage.h
@@ -18,13 +18,15 @@ class Stage {
   Stage();
   ~Stage();
 
+  void Resize(SizeI size, float device_pixel_ratio);
+
   const ViewingVolume& viewing_volume() const { return viewing_volume_; };
   void set_viewing_volume(ViewingVolume value) {
     viewing_volume_ = std::move(value);
   }
 
-  const SizeI& size() const { return viewing_volume_.size(); }
-  void SetSize(SizeI size);
+  const SizeI& physical_size() const { return physical_size_; }
+  void set_physical_size(SizeI value) { physical_size_ = std::move(value); }
 
   const DirectionalLight& key_light() const { return key_light_; }
   void set_key_light(DirectionalLight value) { key_light_ = std::move(value); }
@@ -33,6 +35,7 @@ class Stage {
   void set_fill_light(AmbientLight value) { fill_light_ = std::move(value); }
 
  private:
+  SizeI physical_size_;
   ViewingVolume viewing_volume_;
   DirectionalLight key_light_;
   AmbientLight fill_light_;

--- a/escher/scene/viewing_volume.cc
+++ b/escher/scene/viewing_volume.cc
@@ -12,16 +12,19 @@ namespace escher {
 ViewingVolume::ViewingVolume() {
 }
 
-ViewingVolume::ViewingVolume(SizeI size, float near, float far)
-  : size_(std::move(size)), near_(near), far_(far) {
+ViewingVolume::ViewingVolume(float width, float height, float near, float far)
+  : width_(width), height_(height), near_(near), far_(far) {
 }
 
 ViewingVolume::~ViewingVolume() {
 }
 
+ViewingVolume ViewingVolume::CopyWith(float width, float height) {
+  return ViewingVolume(width, height, near_, far_);
+}
+
 glm::mat4 ViewingVolume::GetProjectionMatrix() const {
-  return glm::ortho<float>(0.0f, size_.width(), size_.height(), 0.0f, -near_,
-                           -far_);
+  return glm::ortho<float>(0.0f, width_, height_, 0.0f, -near_, -far_);
 }
 
 }  // namespace escher

--- a/escher/scene/viewing_volume.h
+++ b/escher/scene/viewing_volume.h
@@ -14,10 +14,13 @@ namespace escher {
 class ViewingVolume {
  public:
   ViewingVolume();
-  ViewingVolume(SizeI size, float near, float far);
+  ViewingVolume(float width, float height, float near, float far);
   ~ViewingVolume();
 
-  const SizeI& size() const { return size_; }
+  ViewingVolume CopyWith(float width, float height);
+
+  float width() const { return width_; }
+  float height() const { return height_; }
   float near() const { return near_; }
   float far() const { return far_; }
 
@@ -26,7 +29,8 @@ class ViewingVolume {
   glm::mat4 GetProjectionMatrix() const;
 
  private:
-  SizeI size_;
+  float width_ = 0.0f;
+  float height_ = 0.0f;
   float near_ = 0.0f;
   float far_ = 0.0f;
 };

--- a/examples/waterfall/app/WaterfallViewController.mm
+++ b/examples/waterfall/app/WaterfallViewController.mm
@@ -69,8 +69,9 @@ static const bool kDrawShadowTestScene = false;
 - (void)update {
   CGFloat contentScaleFactor = self.view.contentScaleFactor;
   CGSize size = self.view.bounds.size;
-  stage_.SetSize(escher::SizeI(size.width * contentScaleFactor,
-                               size.height * contentScaleFactor));
+  stage_.Resize(escher::SizeI(size.width * contentScaleFactor,
+                              size.height * contentScaleFactor),
+                contentScaleFactor);
 }
 
 - (void)glkView:(GLKView*)view drawInRect:(CGRect)rect {
@@ -82,8 +83,8 @@ static const bool kDrawShadowTestScene = false;
   }
 
   if (kDrawShadowTestScene)
-    renderer_->Render(stage_, shadow_test_scene_.GetModel(stage_.size()));
-  renderer_->Render(stage_, app_test_scene_.GetModel(stage_.size(), focus_));
+    renderer_->Render(stage_, shadow_test_scene_.GetModel(stage_.viewing_volume()));
+  renderer_->Render(stage_, app_test_scene_.GetModel(stage_.viewing_volume(), focus_));
 }
 
 - (void)touchesMoved:(NSSet*)touches withEvent:(UIEvent*)event {

--- a/examples/waterfall/scenes/app_test_scene.cc
+++ b/examples/waterfall/scenes/app_test_scene.cc
@@ -28,25 +28,27 @@ AppTestScene::AppTestScene() {
 
 AppTestScene::~AppTestScene() {}
 
-escher::Model AppTestScene::GetModel(const escher::SizeI& size,
+escher::Model AppTestScene::GetModel(const escher::ViewingVolume& volume,
                                      const glm::vec2& focus) {
   std::vector<escher::Object> objects;
 
   // canvas
   objects.emplace_back(
-      escher::Shape::CreateRect(glm::vec2(0.0f, 0.0f), size.AsVec2(), 0.0f),
+      escher::Shape::CreateRect(glm::vec2(0.0f, 0.0f),
+                                glm::vec2(volume.width(), volume.height()),
+                                0.0f),
       &canvas_material_);
 
   // app bar
   objects.emplace_back(
       escher::Shape::CreateRect(glm::vec2(0.0f, 0.0f),
-                                glm::vec2(size.width(), 56.0f), 4.0f),
+                                glm::vec2(volume.width(), 56.0f), 4.0f),
       &app_bar_material_);
 
   // card
   objects.emplace_back(
       escher::Shape::CreateRect(glm::vec2(0.0f, 200.0f),
-                                glm::vec2(size.width(), 120.0f), 2.0f),
+                                glm::vec2(volume.width(), 120.0f), 2.0f),
       &card_material_);
 
   // left eye

--- a/examples/waterfall/scenes/app_test_scene.h
+++ b/examples/waterfall/scenes/app_test_scene.h
@@ -5,15 +5,16 @@
 #pragma once
 
 #include "escher/base/macros.h"
-#include "escher/geometry/size_i.h"
 #include "escher/scene/model.h"
+#include "escher/scene/viewing_volume.h"
 
 class AppTestScene {
  public:
   AppTestScene();
   ~AppTestScene();
 
-  escher::Model GetModel(const escher::SizeI& size, const glm::vec2& focus);
+  escher::Model GetModel(const escher::ViewingVolume& volume,
+                         const glm::vec2& focus);
 
  private:
   escher::Material app_bar_material_;

--- a/examples/waterfall/scenes/material_stage.cc
+++ b/examples/waterfall/scenes/material_stage.cc
@@ -15,7 +15,7 @@ constexpr float kFar = -1.0f;
 
 void InitStageForMaterial(escher::Stage* stage) {
   stage->set_viewing_volume(
-      escher::ViewingVolume(escher::SizeI(), kNear, kFar));
+      escher::ViewingVolume(0.0f, 0.0f, kNear, kFar));
   stage->set_key_light(escher::DirectionalLight(
       glm::vec2(M_PI / 2.0, M_PI / 4.0), M_PI / 4.0, 0.5));
 }

--- a/examples/waterfall/scenes/shadow_test_scene.cc
+++ b/examples/waterfall/scenes/shadow_test_scene.cc
@@ -24,10 +24,10 @@ ShadowTestScene::ShadowTestScene() {
 
 ShadowTestScene::~ShadowTestScene() {}
 
-escher::Model ShadowTestScene::GetModel(const escher::SizeI& size) {
+escher::Model ShadowTestScene::GetModel(const escher::ViewingVolume& volume) {
   std::vector<escher::Object> objects;
 
-  float center = size.width() / 2.0f;
+  float center = volume.width() / 2.0f;
 
   float left[] = {
       kPadding, center + kPadding,
@@ -38,7 +38,8 @@ escher::Model ShadowTestScene::GetModel(const escher::SizeI& size) {
 
   objects.emplace_back(
       escher::Shape::CreateRect(glm::vec2(0.0f, 0.0f),
-                                glm::vec2(size.width(), size.height()), 0.0f),
+                                glm::vec2(volume.width(), volume.height()),
+                                0.0f),
       &card_material_);
 
   for (int i = 0; i < arraysize(kElevations); ++i) {

--- a/examples/waterfall/scenes/shadow_test_scene.h
+++ b/examples/waterfall/scenes/shadow_test_scene.h
@@ -5,15 +5,15 @@
 #pragma once
 
 #include "escher/base/macros.h"
-#include "escher/geometry/size_i.h"
 #include "escher/scene/model.h"
+#include "escher/scene/viewing_volume.h"
 
 class ShadowTestScene {
  public:
   ShadowTestScene();
   ~ShadowTestScene();
 
-  escher::Model GetModel(const escher::SizeI& size);
+  escher::Model GetModel(const escher::ViewingVolume& volume);
 
  private:
   escher::Material card_material_;


### PR DESCRIPTION
Previously we were confused about physical pixels versus logical sizes.
Now ViewingVolume and Object are in logical sizes whereas the stage has
a physical_size that is in physical pixels.
