### PR TITLE
Fix shadows

### DIFF
--- a/escher/shaders/lighting/illumination_reconstruction_filter.cc
+++ b/escher/shaders/lighting/illumination_reconstruction_filter.cc
@@ -25,6 +25,9 @@ constexpr char g_fragment_shader[] = R"GLSL(
 
   const float scene_depth = 26.0;
 
+  // Related to OcclusionDetector::kNoiseSize.
+  // We need the reconstruction filter to remove exactly the frequency of the
+  // noise, which is why these values need to be coordinated.
   #define RADIUS 4
 
   void main() {

--- a/escher/shaders/lighting/occlusion_detector.cc
+++ b/escher/shaders/lighting/occlusion_detector.cc
@@ -45,7 +45,7 @@ constexpr char g_fragment_shader[] = R"GLSL(
   const float kPi = 3.14159265359;
 
   // Must match header.
-  const int kNoiseSize = 8;
+  const int kNoiseSize = 5;
 
   // The numer of screen-space samples to use in the computation.
   const int kTapCount = 8;
@@ -93,7 +93,7 @@ constexpr char g_fragment_shader[] = R"GLSL(
   }
 
   void main() {
-    vec2 seed = texture2D(u_noise, gl_FragCoord.xy / float(kNoiseSize)).rg;
+    vec2 seed = texture2D(u_noise, fract(gl_FragCoord.xy / float(kNoiseSize))).rg;
 
     float fragment_depth_uv = texture2D(u_depth_map, fragment_uv).r;
     float fragment_z = fragment_depth_uv * -u_viewing_volume.z;

--- a/escher/shaders/lighting/occlusion_detector.h
+++ b/escher/shaders/lighting/occlusion_detector.h
@@ -27,8 +27,8 @@ class OcclusionDetector {
   // Attributes
   GLint position() const { return position_; }
 
-  // Must match fragment shader.
-  static const int kNoiseSize = 8;
+  // Must match fragment shader and RADIUS in IlluminationReconstructionFilter.
+  static const int kNoiseSize = 5;
 
  private:
   UniqueProgram program_;

--- a/escher/textures/noise_texture.cc
+++ b/escher/textures/noise_texture.cc
@@ -23,6 +23,8 @@ UniqueTexture MakeNoiseTexture(const SizeI& size) {
   glBindTexture(GL_TEXTURE_2D, result.id());
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, size.width(), size.height(), 0,
                GL_RGBA, GL_UNSIGNED_BYTE, data.get());
   return result;


### PR DESCRIPTION
iOS didn't seem to like us using GL_REPEAT on the dither pattern, so now
we use GL_CLAMP_TO_EDGE and fract to do the wrapping.
